### PR TITLE
Prevent the getDatabaseLocked() NPE on layout editor

### DIFF
--- a/PersistentEditText/src/main/java/org/wordpress/persistentedittext/PersistentEditText.java
+++ b/PersistentEditText/src/main/java/org/wordpress/persistentedittext/PersistentEditText.java
@@ -37,7 +37,9 @@ public class PersistentEditText extends EditText {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        load();
+        if (!isInEditMode()) {
+            load();
+        }
     }
 
     @Override protected void onTextChanged(CharSequence text, int start, int lengthBefore, int lengthAfter) {


### PR DESCRIPTION
Fixes #1 

Disables the loading from the DB when ran from inside the AS layout editor.